### PR TITLE
Fixing buggy service workers

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -22,6 +22,23 @@ if (process.env.NODE_ENV === 'production') {
   );
 }
 
+// Un-register buggy service workers that got deployed when first
+// publishing the new design (2018-05-06)
+// Deprecate this within a month or so
+const getScriptToUnregisterBuggyServiceWorkers = () => ({
+  __html: `
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then(function (registrations) {
+        if (registrations.length) {
+          for(let registration of registrations) {
+            registration.unregister();
+          }
+        }
+      });
+    }
+  `,
+});
+
 const HTML = ({
   htmlAttributes,
   headComponents,
@@ -40,6 +57,9 @@ const HTML = ({
       />
       {headComponents}
       {css}
+      <script
+        dangerouslySetInnerHTML={getScriptToUnregisterBuggyServiceWorkers()}
+      />
     </head>
     <body {...bodyAttributes}>
       {preBodyComponents}


### PR DESCRIPTION
When publishing the new design (2018-05-06) `gatsby-plugin-offline`
as added which installed a ServiceWorker.

For some early users this cached a buggy version of the site.
The site broke when deploying to the prod bucket where the same
build worked on the test bucket.
This is most likely caused by bad caching policies on S3.
We no longer use S3 for deployment so we hopefully won't have
the similar issue.

Gatsby now writes custom caching headers for Netlify.

Reverted here: https://github.com/HedvigInsurance/web/commit/46b56649dd73b739783f8bb9defcd042d27da9ed#diff-b9e136416b90437fa1dac910280b45fc